### PR TITLE
Windows paths

### DIFF
--- a/WASMbindgenAsset.js
+++ b/WASMbindgenAsset.js
@@ -140,6 +140,7 @@ class WASMbindgenAsset extends Asset {
     let wasm_path = path.relative(path.dirname(this.name), path.join(loc, rustName + '_bg.wasm'))
     if (wasm_path[0] !== '.')
       wasm_path = './' + wasm_path
+    wasm_path = wasm_path.replace('\\', '/')
 
     js_content = js_content.replace(/import\ \*\ as\ wasm.+?;/, 'var wasm;const __exports = {};')
 


### PR DESCRIPTION
Fixes parcel-plugin-wasm.rs for Windows users, dirty but works.

Otherwise would merge `./pkg` with no delimeter like `./pkgrust-parcel-template_bg.wasm`