### PR TITLE
Fix snippets path for Windows

### DIFF
--- a/WASMbindgenAsset.js
+++ b/WASMbindgenAsset.js
@@ -144,7 +144,9 @@ class WASMbindgenAsset extends Asset {
 
     js_content = js_content.replace(/import\ \*\ as\ wasm.+?;/, 'var wasm;const __exports = {};')
     js_content = js_content.replace(/import.+?snippets.+?;/g, line => {
-      return line.replace('./snippets', path.relative(__dirname + '/', path.join(cargoDir, 'pkg/snippets/')))
+      return line
+        .replace('./snippets', path.relative(__dirname + '/', path.join(cargoDir, 'pkg/snippets/')))
+        .replace(/\\/g, '/')
     })
 
     const export_names = []


### PR DESCRIPTION
Snippets path incorrectly generated with backslash separators which caused parcel to
fail on Window.

This is related to issue #20 and commit ea226f8