### PR TITLE
Update to match the changes in wasm-bindgen

### DIFF
--- a/WASMbindgenAsset.js
+++ b/WASMbindgenAsset.js
@@ -133,14 +133,14 @@ class WASMbindgenAsset extends Asset {
         outDir,
         rustName,
         loc: path.join(cargoDir, 'target', RUST_TARGET, 'release')
-      } 
+      }
     } catch (e) {
       throw `Building failed... Please install wasm-pack and try again.`
     }
   }
 
   async wasmPostProcess({cargoDir, loc, outDir, rustName, target_folder}) {
-    let js_content = (await lib.readFile(path.join(outDir, rustName + '.js'))).toString()
+    let js_content = (await lib.readFile(path.join(outDir, rustName + '_bg.js'))).toString()
     let wasm_path = path.relative(path.dirname(this.name), path.join(loc, rustName + '_bg.wasm'))
     if (wasm_path[0] !== '.')
       wasm_path = './' + wasm_path
@@ -188,11 +188,11 @@ class WASMbindgenAsset extends Asset {
           const fetchPromise = fetch(wasm_path);
           let resultPromise;
           if (typeof WebAssembly.instantiateStreaming === 'function') {
-              resultPromise = WebAssembly.instantiateStreaming(fetchPromise, { './${rustName}.js': __exports });
+              resultPromise = WebAssembly.instantiateStreaming(fetchPromise, { './${rustName}_bg.js': __exports });
           } else {
               resultPromise = fetchPromise
               .then(response => response.arrayBuffer())
-              .then(buffer => WebAssembly.instantiate(buffer, { './${rustName}.js': __exports }));
+              .then(buffer => WebAssembly.instantiate(buffer, { './${rustName}_bg.js': __exports }));
           }
           return resultPromise.then(({instance}) => {
               wasm = init.wasm = instance.exports;
@@ -211,7 +211,7 @@ class WASMbindgenAsset extends Asset {
                   }
               });
           })
-          .then(data => WebAssembly.instantiate(data, { './${rustName}': __exports }))
+          .then(data => WebAssembly.instantiate(data, { './${rustName}_bg': __exports }))
           .then(({instance}) => {
               wasm = init.wasm = instance.exports;
               __exports.wasm = wasm;


### PR DESCRIPTION
I tried to switch to using `--target web` (and `--target node` for node) as @Pauan suggested, but ran into some trouble. My attempt is [here](https://github.com/rrbutani/parcel-plugin-wasm.rs/commit/176bfa658d354e4cc935265c230fc7d8d4ffa855) but the key points are that:
  - the use of `import.meta` in the JS that `wasm-bindgen` produces with `--target web` is problematic because:
     - `parcel` can't see through that import
     - `babel` doesn't yet support this (babel/babel#11364)
        + there's [a plugin](https://babeljs.io/docs/en/next/babel-plugin-syntax-import-meta.html) that enables this though
     - if I understand correctly, `import.meta` can only be used _within_ an ES module which is problematic for the output that `parcel` produces

Just using the bundler target without any "custom parsing" doesn't work because `parcel`'s built-in wasm loaders ([here](https://github.com/parcel-bundler/parcel/blob/b275d0962da1ff200028760f2b1e227dd54ccf95/packages/core/parcel-bundler/src/builtins/loaders/browser/wasm-loader.js#L1-L16) and [here](https://github.com/parcel-bundler/parcel/blob/b275d0962da1ff200028760f2b1e227dd54ccf95/packages/core/parcel-bundler/src/builtins/loaders/node/wasm-loader.js#L3-L19)) don't pass in any imports.

[By contrast](https://github.com/parcel-bundler/parcel/issues/647), webpack does the right here which is why its' plugin doesn't need to remap the imports/exports and manually import the wasm blob. [This](https://github.com/mysterycommand/parcel-plugin-wasm-pack/) other parcel plugin also uses the bundler target and [remaps the imports and exports](https://github.com/mysterycommand/parcel-plugin-wasm-pack/blob/f204a708d964127aaa1e5d278f41a44f5d76393b/src/WasmPackAsset.js#L174-L215) but then appears to go and replace the default `parcel` wasm loader [with their own version](https://github.com/mysterycommand/parcel-plugin-wasm-pack/blob/master/src/loaders/browser-wasm-loader.js) that takes imports as an arg (this plugin effectively does the exact same thing, I think).

It seems like if this plugin were to use `--target web` and manually substitute the `import.meta` call for the actual file name of the wasm blob (and then also make it so `parcel` picks up and serves the blob) things would work. I'm not sure what the best way to do the latter thing is (raw asset? just copy it into the output directory? I know that putting it in `generated` under the `wasm` key won't work since, again, the default wasm loader doesn't support imports).

I'm also not sure that the workaround above (assuming it'd work) is actually appreciably better than the current way of doing things (it'd be more resilient to changes in how, for example, enums are exported in `wasm-bindgen` and that sort of thing but I don't know if it matters). In any case, I'm not very familiar with JavaScript build tooling so I thought I'd write all this out and make sure I'm not completely wrong about the above or missing something.

In the meantime, as the commit says, here's a stopgap that just goes and uses the `_bg.js` file where it's needed so things work as they did before.

This closes #30.
